### PR TITLE
Added test of docker command line

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -52,4 +52,4 @@ jobs:
           flake8 . --count --max-line-length=300 --show-source --statistics
       - name: Test with pytest
         run: |
-          pytest
+          pytest --basetemp /tmp/${{ github.actor }}/pytest_of_dog

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -52,4 +52,4 @@ jobs:
           flake8 . --count --max-line-length=300 --show-source --statistics
       - name: Test with pytest
         run: |
-          pytest --basetemp /tmp/${{ github.actor }}/pytest_of_dog
+          pytest --basetemp /home/runner/work/dog/pytest_tmp_dir

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # We want to support python 3.5 and forward (since python 3.5 is the default python on current debian stable)
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -52,4 +52,4 @@ jobs:
           flake8 . --count --max-line-length=300 --show-source --statistics
       - name: Test with pytest
         run: |
-          pytest --basetemp /home/runner/work/dog/pytest_tmp_dir
+          pytest

--- a/dog.py
+++ b/dog.py
@@ -202,7 +202,7 @@ def get_env_config() -> DogConfig:
         import grp
         config[UID] = os.getuid()
         config[GID] = os.getgid()
-        config[HOME] = os.getenv('HOME')
+        config[HOME] = str(Path.home())
         config[USER] = os.getenv('USER')
         config[GROUP] = grp.getgrgid(config['gid']).gr_name
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -69,16 +70,6 @@ def call_main(my_dog, tmp_path, monkeypatch):
         for arg in args:
             cmd_line.append(str(arg))
         with monkeypatch.context() as m:
-            # Make the tmp_path (cwd) look like a mount point
-            real_os_path_is_mount = os.path.ismount
-
-            def my_is_mount(s):
-                if s == str(tmp_path):
-                    return True
-                else:
-                    return real_os_path_is_mount(s)
-
-            m.setattr(os.path, 'ismount', my_is_mount)
             m.chdir(tmp_path)
             return main(cmd_line)
 
@@ -121,4 +112,5 @@ def home_temp_dir(tmp_path_factory, monkeypatch) -> Path:
     monkeypatch.setattr(Path, 'home', lambda: tmphome)
     if not is_windows():
         monkeypatch.setenv('HOME', str(tmphome))
-    return tmphome
+    yield tmphome
+    shutil.rmtree(tmphome)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,5 @@ def system_temp_dir() -> str:
 def home_temp_dir(tmp_path_factory, monkeypatch) -> Path:
     tmphome = tmp_path_factory.mktemp('home')
     monkeypatch.setattr(Path, 'home', lambda: tmphome)
-    if not is_windows():
-        monkeypatch.setenv('HOME', str(tmphome))
     yield tmphome
     shutil.rmtree(tmphome)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,10 @@ ACTUAL_DOG_VERSION = VERSION
 DOG_PYTHON_UNDER_TEST = os.getenv('DOG_PYTHON_UNDER_TEST', sys.executable)
 
 
+def is_windows() -> bool:
+    return 'win32' in sys.platform
+
+
 @pytest.fixture
 def capstrip(capfd):
     class CapStrip:
@@ -27,7 +31,7 @@ def capstrip(capfd):
 
 @pytest.fixture
 def uid() -> int:
-    if 'win32' in sys.platform:
+    if is_windows():
         return 1000
     else:
         return os.getuid()
@@ -73,7 +77,7 @@ def call_main(my_dog, tmp_path, monkeypatch):
 
 @pytest.fixture
 def dog_env():
-    if 'win32' in sys.platform:
+    if is_windows():
         return '%DOG%'
     else:
         return '$DOG'
@@ -91,7 +95,7 @@ def append_to_dog_config(tmp_path: Path, extra_dog_config: str):
 
 @pytest.fixture
 def system_temp_dir() -> str:
-    if sys.platform == 'win32':
+    if is_windows():
         basedir = os.environ['TEMP']
     else:
         basedir = os.getenv('RUNNER_TEMP', '/tmp')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,4 +109,6 @@ def system_temp_dir() -> str:
 def home_temp_dir(tmp_path_factory, monkeypatch) -> Path:
     tmphome = tmp_path_factory.mktemp('home')
     monkeypatch.setattr(Path, 'home', lambda: tmphome)
+    if not is_windows():
+        monkeypatch.setenv('HOME', str(tmphome))
     return tmphome

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,15 @@ def call_main(my_dog, tmp_path, monkeypatch):
             cmd_line.append(str(arg))
         with monkeypatch.context() as m:
             # Make the tmp_path (cwd) look like a mount point
-            monkeypatch.setattr(os.path, 'ismount', lambda s: s == str(tmp_path))
+            real_os_path_is_mount = os.path.ismount
+
+            def my_is_mount(s):
+                if s == str(tmp_path):
+                    return True
+                else:
+                    return real_os_path_is_mount(s)
+
+            m.setattr(os.path, 'ismount', my_is_mount)
             m.chdir(tmp_path)
             return main(cmd_line)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -70,6 +69,8 @@ def call_main(my_dog, tmp_path, monkeypatch):
         for arg in args:
             cmd_line.append(str(arg))
         with monkeypatch.context() as m:
+            # Make the tmp_path (cwd) look like a mount point
+            monkeypatch.setattr(os.path, 'ismount', lambda s: s == str(tmp_path))
             m.chdir(tmp_path)
             return main(cmd_line)
 
@@ -112,5 +113,4 @@ def home_temp_dir(tmp_path_factory, monkeypatch) -> Path:
     monkeypatch.setattr(Path, 'home', lambda: tmphome)
     if not is_windows():
         monkeypatch.setenv('HOME', str(tmphome))
-    yield tmphome
-    shutil.rmtree(tmphome)
+    return tmphome

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -111,4 +112,5 @@ def home_temp_dir(tmp_path_factory, monkeypatch) -> Path:
     monkeypatch.setattr(Path, 'home', lambda: tmphome)
     if not is_windows():
         monkeypatch.setenv('HOME', str(tmphome))
-    return tmphome
+    yield tmphome
+    shutil.rmtree(tmphome)

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -146,9 +146,10 @@ def std_assert_volume_params(args_left):
         return assert_volume_params(args_left, [('/C', 'C:\\'), ('/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')), ('/home/dog_test_user/.p4tickets:ro', str(Path.home() / 'dog_p4tickets.txt'))])
     else:
         mount_point = str(find_mount_point(Path.cwd()))
+        user = os.getenv('USER')
         return assert_volume_params(args_left, [(mount_point, mount_point),
-                                                ('/home/test_home/.ssh:ro', str(Path.home() / '.ssh')),
-                                                ('/home/test_home/.p4tickets:ro', str(Path.home() / '.p4tickets'))])
+                                                (f'/home/{user}/.ssh:ro', str(Path.home() / '.ssh')),
+                                                (f'/home/{user}/.p4tickets:ro', str(Path.home() / '.p4tickets'))])
 
 
 def std_assert_interactive(args_left):

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -1,0 +1,261 @@
+import dog
+import grp
+import itertools
+import os
+import pytest
+import subprocess
+import sys
+from collections.abc import Iterable
+from conftest import append_to_dog_config, is_windows
+from dog import DogConfig
+from pathlib import Path, PureWindowsPath
+from typing import List, Tuple
+
+
+class MockSubprocess:
+    def __init__(self):
+        self.run_args = None
+
+    def mock_run(self, *args, **kwargs):
+        self.run_args = args[0]
+        return subprocess.CompletedProcess(args=args, returncode=0)
+
+
+@pytest.fixture
+def mock_subprocess(monkeypatch) -> MockSubprocess:
+    m = MockSubprocess()
+    monkeypatch.setattr(subprocess, 'run', m.mock_run)
+    return m
+
+
+@pytest.fixture(autouse=True)
+def mock_env_user(monkeypatch):
+    monkeypatch.setenv('USER', 'test_user')
+
+
+@pytest.fixture(autouse=True)
+def mock_env_home(monkeypatch):
+    monkeypatch.setenv('HOME', '/home/test_home')
+
+
+@pytest.fixture(autouse=True)
+def mock_getuid(monkeypatch):
+    uid = 1000 if is_windows() else 1122
+    monkeypatch.setattr(os, 'getuid', lambda: uid)
+
+
+@pytest.fixture(autouse=True)
+def mock_group(monkeypatch):
+    gid = 1000 if is_windows() else 5566
+    monkeypatch.setattr(os, 'getgid', lambda: gid)
+    if not is_windows():
+        class MockGroup:
+            gr_name = 'test_group'
+        monkeypatch.setattr(grp, 'getgrgid', lambda x: MockGroup())
+
+
+def split_single_cmdline_param(param: str, args: List[str], include_value: bool = False) -> Tuple[List[str], List[str]]:
+    param_list = []
+    args_left = []
+    i = iter(args)
+    try:
+        while True:
+            item = next(i)
+            if not item.startswith(param):
+                args_left.append(item)
+                continue
+            param_list.append(item)
+            if include_value:
+                param_list.append(next(i))
+    except StopIteration:
+        pass
+    return (param_list, args_left)
+
+
+def flatten(container: Iterable) -> List:
+    return list(itertools.chain.from_iterable(container))
+
+
+def assert_docker_std_cmdline(run_args: List[str], sudo_outside: bool = False) -> List[str]:
+    expected_args = []
+    if sudo_outside:
+        expected_args.append('sudo')
+    expected_args.extend(['docker', 'run', '--rm'])
+    assert expected_args == run_args[:len(expected_args)]
+    return run_args[len(expected_args):]
+
+
+def assert_docker_image_and_cmd_inside_docker(run_args: List[str], expected_docker_image: str, expected_cmd_inside_docker: List[str]) -> List[str]:
+    run_args_cmd_inside_docker = run_args[-len(expected_cmd_inside_docker):]
+    assert expected_cmd_inside_docker == run_args_cmd_inside_docker
+    assert expected_docker_image == run_args[-(len(expected_cmd_inside_docker) + 1)]
+    return run_args[:-(len(expected_cmd_inside_docker) + 1)]
+
+
+def assert_workdir_param(run_args: List[str], expected_workdir_path: Path) -> List[str]:
+    workdir_params, args_left = split_single_cmdline_param('-w', run_args, include_value=True)
+    assert ['-w', str(expected_workdir_path)] == workdir_params
+    return args_left
+
+
+def assert_hostname_param(run_args: List[str], expected_hostname: str) -> List[str]:
+    hostname_params, args_left = split_single_cmdline_param('--hostname=', run_args)
+    assert ['--hostname={}'.format(expected_hostname)] == hostname_params
+    return args_left
+
+
+def assert_volume_params(run_args: List[str], expected_volume_mappings: List[Tuple[str, str]]) -> List[str]:
+    volume_params, args_left = split_single_cmdline_param('-v', run_args, include_value=True)
+    vol_mapping_values = ['{}:{}'.format(vm[1], vm[0]) for vm in expected_volume_mappings]
+    expected_volume_params = flatten(zip(['-v'] * len(expected_volume_mappings), vol_mapping_values))
+    assert expected_volume_params == volume_params
+    return args_left
+
+
+def assert_interactive(run_args: List[str], expected_interactive: bool) -> List[str]:
+    interactive_param, args_left = split_single_cmdline_param('-i', run_args)
+    expected_interactive_param = ['-i'] if expected_interactive else []
+    assert expected_interactive_param == interactive_param
+    return args_left
+
+
+def assert_env_params(run_args: List[str], expected_env_values: List[str]) -> List[str]:
+    env_params, args_left = split_single_cmdline_param('-e', run_args, include_value=True)
+    expected_env_params = flatten(zip(['-e'] * len(expected_env_values), expected_env_values))
+    assert expected_env_params == env_params
+    return args_left
+
+
+def std_assert_hostname_param(args_left):
+    return assert_hostname_param(args_left, 'dog_docker')
+
+
+def std_assert_volume_params(args_left):
+    return assert_volume_params(args_left, [('/tmp', '/tmp'), ('/home/test_home/.ssh:ro', '/home/test_home/.ssh'), ('/home/test_home/.p4tickets:ro', '/home/test_home/.p4tickets')])
+
+
+def std_assert_interactive(args_left):
+    return assert_interactive(args_left, True)
+
+
+def std_assert_env_params(args_left):
+    return assert_env_params(args_left, ['USER=test_user', 'P4USER=test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1122', 'DOG_GID=5566', 'DOG_USER=test_user', 'DOG_GROUP=test_group', 'DOG_HOME=/home/test_home', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+
+
+def test_simple_docker_cmdline(call_main, tmp_path, mock_subprocess):
+    append_to_dog_config(tmp_path, '[dog]\nimage=rtol/centos-for-dog\n')
+    call_main('echo', 'foo')
+    args_left = assert_docker_std_cmdline(mock_subprocess.run_args)
+    args_left = assert_docker_image_and_cmd_inside_docker(args_left, 'rtol/centos-for-dog', ['echo', 'foo'])
+    args_left = assert_workdir_param(args_left, tmp_path)
+    args_left = std_assert_hostname_param(args_left)
+    args_left = std_assert_volume_params(args_left)
+    args_left = std_assert_interactive(args_left)
+    args_left = std_assert_env_params(args_left)
+    assert args_left == []
+
+
+@pytest.mark.parametrize('image_name', ['my_little_image', 'a/path/based/image'])
+def test_images(call_main, tmp_path, mock_subprocess, image_name: str):
+    append_to_dog_config(tmp_path, '[dog]\nimage={}\n'.format(image_name))
+    call_main('echo', 'foo')
+    args_left = assert_docker_std_cmdline(mock_subprocess.run_args)
+    args_left = assert_docker_image_and_cmd_inside_docker(args_left, image_name, ['echo', 'foo'])
+    args_left = assert_workdir_param(args_left, tmp_path)
+    args_left = std_assert_hostname_param(args_left)
+    args_left = std_assert_volume_params(args_left)
+    args_left = std_assert_interactive(args_left)
+    args_left = std_assert_env_params(args_left)
+    assert args_left == []
+
+
+@pytest.mark.parametrize('cmds', [['echo', 'foo'], ['cat', '/tmp/test.txt'], ['my_cmd']])
+def test_commands_in_docker(call_main, tmp_path, mock_subprocess, cmds: List[str]):
+    append_to_dog_config(tmp_path, '[dog]\nimage=my_image\n')
+    call_main(*cmds)
+    args_left = assert_docker_std_cmdline(mock_subprocess.run_args)
+    args_left = assert_docker_image_and_cmd_inside_docker(args_left, 'my_image', cmds)
+    args_left = assert_workdir_param(args_left, tmp_path)
+    args_left = std_assert_hostname_param(args_left)
+    args_left = std_assert_volume_params(args_left)
+    args_left = std_assert_interactive(args_left)
+    args_left = std_assert_env_params(args_left)
+    assert args_left == []
+
+
+@pytest.mark.parametrize('test_sudo', [('sudo-outside-docker=True', True), ('sudo-outside-docker=False', False), ('', False)])
+def test_sudo_outside(call_main, tmp_path, mock_subprocess, test_sudo: List[Tuple[str, bool]]):
+    append_to_dog_config(tmp_path, '[dog]\nimage=my_image\n{}\n'.format(test_sudo[0]))
+    call_main('my_inside_cmd')
+    args_left = assert_docker_std_cmdline(mock_subprocess.run_args, test_sudo[1])
+    args_left = assert_docker_image_and_cmd_inside_docker(args_left, 'my_image', ['my_inside_cmd'])
+    args_left = assert_workdir_param(args_left, tmp_path)
+    args_left = std_assert_hostname_param(args_left)
+    args_left = std_assert_volume_params(args_left)
+    args_left = std_assert_interactive(args_left)
+    args_left = std_assert_env_params(args_left)
+    assert args_left == []
+
+
+@pytest.mark.parametrize('auto_mount', [('auto-mount=True', [('/tmp', '/tmp')]), ('auto-mount=False', []), ('', [('/tmp', '/tmp')])])
+def test_auto_mount(call_main, tmp_path, mock_subprocess, auto_mount: List[Tuple[str, List[Tuple[str, str]]]]):
+    append_to_dog_config(tmp_path, '[dog]\nimage=my_image\nperforce=False\nssh=False\n{}\n'.format(auto_mount[0]))
+    call_main('my_inside_cmd')
+    args_left = assert_docker_std_cmdline(mock_subprocess.run_args)
+    args_left = assert_docker_image_and_cmd_inside_docker(args_left, 'my_image', ['my_inside_cmd'])
+    args_left = assert_workdir_param(args_left, tmp_path)
+    args_left = std_assert_hostname_param(args_left)
+    args_left = assert_volume_params(args_left, auto_mount[1])
+    args_left = std_assert_interactive(args_left)
+    args_left = std_assert_env_params(args_left)
+    assert args_left == []
+
+
+class MockReadDogConfig:
+    def __init__(self, orig_read_dog_config, win_path, config_path):
+        self.orig_read_dog_config = orig_read_dog_config
+        self.win_path = win_path
+        self.config_path = config_path
+
+    def mocked_read_dog_config(self, dog_config: Path) -> DogConfig:
+        path_to_dog_config = self.config_path if dog_config == self.win_path else dog_config
+        return self.orig_read_dog_config(path_to_dog_config)
+
+
+def mock_win32(monkeypatch, tmp_path, win_path, dog_config_contents: str):
+    monkeypatch.setattr(sys, 'platform', 'win32')
+    monkeypatch.setenv('USERNAME', 'test_user')
+    monkeypatch.setattr(Path, 'cwd', lambda: win_path)
+    monkeypatch.setattr(os.path, 'isfile', lambda x: True)
+    append_to_dog_config(tmp_path, dog_config_contents)
+    mrdc = MockReadDogConfig(dog.read_dog_config, win_path / 'dog.config', tmp_path / 'dog.config')
+    monkeypatch.setattr(dog, 'read_dog_config', mrdc.mocked_read_dog_config)
+
+
+def test_auto_mount_win32(call_main, tmp_path, mock_subprocess, monkeypatch):
+    win_path = PureWindowsPath('C:\\tmp\\test')
+    mock_win32(monkeypatch, tmp_path, win_path, '[dog]\nimage=my_image\nperforce=False\nssh=False\n')
+    call_main('my_inside_cmd')
+    args_left = assert_docker_std_cmdline(mock_subprocess.run_args)
+    args_left = assert_docker_image_and_cmd_inside_docker(args_left, 'my_image', ['my_inside_cmd'])
+    args_left = assert_workdir_param(args_left, '/C/tmp/test')
+    args_left = std_assert_hostname_param(args_left)
+    args_left = assert_volume_params(args_left, [('/C', 'C:\\')])
+    args_left = std_assert_interactive(args_left)
+    args_left = assert_env_params(args_left, ['USER=test_user', 'P4USER=test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+    assert args_left == []
+
+
+def test_perforce_win32(call_main, tmp_path, mock_subprocess, monkeypatch, home_temp_dir):
+    win_path = PureWindowsPath('C:\\tmp\\test')
+    mock_win32(monkeypatch, tmp_path, win_path, '[dog]\nimage=my_image\nauto-mount=False\nperforce=True\nssh=False\n')
+    call_main('my_inside_cmd')
+    args_left = assert_docker_std_cmdline(mock_subprocess.run_args)
+    args_left = assert_docker_image_and_cmd_inside_docker(args_left, 'my_image', ['my_inside_cmd'])
+    args_left = assert_workdir_param(args_left, '/C/tmp/test')
+    args_left = std_assert_hostname_param(args_left)
+    args_left = assert_volume_params(args_left, [('/home/test_user/.p4tickets:ro', str(home_temp_dir / 'dog_p4tickets.txt'))])
+    args_left = std_assert_interactive(args_left)
+    args_left = assert_env_params(args_left, ['USER=test_user', 'P4USER=test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+    assert args_left == []
+

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -138,7 +138,9 @@ def std_assert_hostname_param(args_left):
 
 def std_assert_volume_params(tmp_path, args_left):
     if is_windows():
-        return assert_volume_params(args_left, [('/C', 'C:\\'), ('/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')), ('/home/dog_test_user/.p4tickets:ro', str(Path.home() / 'dog_p4tickets.txt'))])
+        return assert_volume_params(args_left, [('/C', 'C:\\'),
+                                                ('/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')),
+                                                ('/home/dog_test_user/.p4tickets:ro', str(Path.home() / 'dog_p4tickets.txt'))])
     else:
         mount_point = str(find_mount_point(tmp_path))
         return assert_volume_params(args_left, [(mount_point, mount_point),
@@ -152,9 +154,13 @@ def std_assert_interactive(args_left):
 
 def std_assert_env_params(home_temp_dir, args_left):
     if is_windows():
-        return assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=my_perforce_server:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=dog_test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/dog_test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+        return assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=my_perforce_server:5000',
+                                             'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=dog_test_user', 'DOG_GROUP=nodoggroup',
+                                             'DOG_HOME=/home/dog_test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
     else:
-        return assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=my_perforce_server:5000', 'DOG_UID=1122', 'DOG_GID=5566', 'DOG_USER=dog_test_user', 'DOG_GROUP=test_group', f'DOG_HOME={home_temp_dir}', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+        return assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=my_perforce_server:5000',
+                                             'DOG_UID=1122', 'DOG_GID=5566', 'DOG_USER=dog_test_user', 'DOG_GROUP=test_group',
+                                             f'DOG_HOME={home_temp_dir}', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
 
 
 def get_workdir(pth: Path) -> str:
@@ -272,7 +278,9 @@ def test_auto_mount_win32(call_main, tmp_path, mock_subprocess, monkeypatch):
     args_left = assert_volume_params(args_left, [('/C', 'C:\\')])
     args_left = std_assert_interactive(args_left)
     args_left = assert_env_params(args_left,
-                                  ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=my_perforce_server:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=dog_test_user', 'DOG_GROUP=nodoggroup', f'DOG_HOME=/home/dog_test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+                                  ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=my_perforce_server:5000',
+                                   'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=dog_test_user', 'DOG_GROUP=nodoggroup',
+                                   'DOG_HOME=/home/dog_test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
     assert args_left == []
 
 
@@ -286,5 +294,7 @@ def test_perforce_win32(call_main, tmp_path, mock_subprocess, monkeypatch, home_
     args_left = std_assert_hostname_param(args_left)
     args_left = assert_volume_params(args_left, [('/home/dog_test_user/.p4tickets:ro', str(home_temp_dir / 'dog_p4tickets.txt'))])
     args_left = std_assert_interactive(args_left)
-    args_left = assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=my_perforce_server:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=dog_test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/dog_test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+    args_left = assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=my_perforce_server:5000',
+                                              'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=dog_test_user', 'DOG_GROUP=nodoggroup',
+                                              'DOG_HOME=/home/dog_test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
     assert args_left == []

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -46,7 +46,7 @@ def mock_env_home(monkeypatch, home_temp_dir):
 
 
 @pytest.fixture(autouse=True)
-def mock_getuid(monkeypatch):
+def mock_getuid(monkeypatch, tmp_path):
     uid = 1000 if is_windows() else 1122
     if not is_windows():
         monkeypatch.setattr(os, 'getuid', lambda: uid)

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -34,7 +34,6 @@ def mock_env_user(monkeypatch):
     if is_windows():
         monkeypatch.setenv('USERNAME', 'dog_test_user')
     else:
-        monkeypatch.setenv('ACTUAL_USER', os.getenv('USER'))
         monkeypatch.setenv('USER', 'dog_test_user')
     monkeypatch.setenv('P4USER', 'dog_test_user')
     monkeypatch.setenv('P4PORT', 'my_perforce_server:5000')
@@ -42,7 +41,8 @@ def mock_env_user(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def mock_env_home(monkeypatch, home_temp_dir):
-    pass
+    if not is_windows():
+        monkeypatch.setenv('HOME', '/home/dog_test_user')
 
 
 @pytest.fixture(autouse=True)
@@ -147,10 +147,9 @@ def std_assert_volume_params(args_left):
         return assert_volume_params(args_left, [('/C', 'C:\\'), ('/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')), ('/home/dog_test_user/.p4tickets:ro', str(Path.home() / 'dog_p4tickets.txt'))])
     else:
         mount_point = str(find_mount_point(Path.cwd()))
-        user = os.getenv('ACTUAL_USER')
         return assert_volume_params(args_left, [(mount_point, mount_point),
-                                                (f'/home/{user}/.ssh:ro', str(Path.home() / '.ssh')),
-                                                (f'/home/{user}/.p4tickets:ro', str(Path.home() / '.p4tickets'))])
+                                                (f'/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')),
+                                                (f'/home/dog_test_user/.p4tickets:ro', str(Path.home() / '.p4tickets'))])
 
 
 def std_assert_interactive(args_left):

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -1,14 +1,16 @@
-import dog
 import itertools
 import os
-import pytest
 import subprocess
 import sys
 from collections.abc import Iterable
-from conftest import append_to_dog_config, is_windows
-from dog import DogConfig, win32_to_dog_unix
 from pathlib import Path, PureWindowsPath
 from typing import List, Tuple
+
+import pytest
+
+import dog
+from conftest import append_to_dog_config, is_windows
+from dog import DogConfig, win32_to_dog_unix
 
 
 class MockSubprocess:
@@ -39,7 +41,7 @@ def mock_env_user(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def mock_env_home(monkeypatch, home_temp_dir):
-    #monkeypatch.setenv('HOME', '/home/test_home')
+    # monkeypatch.setenv('HOME', '/home/test_home')
     pass
 
 
@@ -60,6 +62,7 @@ def mock_group(monkeypatch):
 
         class MockGroup:
             gr_name = 'test_group'
+
         monkeypatch.setattr(grp, 'getgrgid', lambda x: MockGroup())
 
 

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -41,7 +41,6 @@ def mock_env_user(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def mock_env_home(monkeypatch, home_temp_dir):
-    # monkeypatch.setenv('HOME', '/home/test_home')
     pass
 
 
@@ -147,7 +146,9 @@ def std_assert_volume_params(args_left):
         return assert_volume_params(args_left, [('/C', 'C:\\'), ('/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')), ('/home/dog_test_user/.p4tickets:ro', str(Path.home() / 'dog_p4tickets.txt'))])
     else:
         mount_point = str(find_mount_point(Path.cwd()))
-        return assert_volume_params(args_left, [(mount_point, mount_point), ('/home/test_home/.ssh:ro', '/home/test_home/.ssh'), ('/home/test_home/.p4tickets:ro', '/home/test_home/.p4tickets')])
+        return assert_volume_params(args_left, [(mount_point, mount_point),
+                                                ('/home/test_home/.ssh:ro', str(Path.home() / '.ssh')),
+                                                ('/home/test_home/.p4tickets:ro', str(Path.home() / '.p4tickets'))])
 
 
 def std_assert_interactive(args_left):

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -30,7 +30,7 @@ def mock_subprocess(monkeypatch) -> MockSubprocess:
 
 @pytest.fixture(autouse=True)
 def mock_env_user(monkeypatch):
-    monkeypatch.setenv('USER', 'test_user')
+    monkeypatch.setenv('USER', 'dog_test_user')
 
 
 @pytest.fixture(autouse=True)
@@ -139,7 +139,7 @@ def std_assert_interactive(args_left):
 
 
 def std_assert_env_params(args_left):
-    return assert_env_params(args_left, ['USER=test_user', 'P4USER=test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1122', 'DOG_GID=5566', 'DOG_USER=test_user', 'DOG_GROUP=test_group', 'DOG_HOME=/home/test_home', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+    return assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1122', 'DOG_GID=5566', 'DOG_USER=dog_test_user', 'DOG_GROUP=test_group', 'DOG_HOME=/home/test_home', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
 
 
 def test_simple_docker_cmdline(call_main, tmp_path, mock_subprocess):
@@ -224,7 +224,7 @@ class MockReadDogConfig:
 
 def mock_win32(monkeypatch, tmp_path, win_path, dog_config_contents: str):
     monkeypatch.setattr(sys, 'platform', 'win32')
-    monkeypatch.setenv('USERNAME', 'test_user')
+    monkeypatch.setenv('USERNAME', 'dog_test_user')
     monkeypatch.setattr(Path, 'cwd', lambda: win_path)
     monkeypatch.setattr(os.path, 'isfile', lambda x: True)
     append_to_dog_config(tmp_path, dog_config_contents)
@@ -242,7 +242,7 @@ def test_auto_mount_win32(call_main, tmp_path, mock_subprocess, monkeypatch):
     args_left = std_assert_hostname_param(args_left)
     args_left = assert_volume_params(args_left, [('/C', 'C:\\')])
     args_left = std_assert_interactive(args_left)
-    args_left = assert_env_params(args_left, ['USER=test_user', 'P4USER=test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+    args_left = assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=dog_test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/dog_test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
     assert args_left == []
 
 
@@ -254,7 +254,7 @@ def test_perforce_win32(call_main, tmp_path, mock_subprocess, monkeypatch, home_
     args_left = assert_docker_image_and_cmd_inside_docker(args_left, 'my_image', ['my_inside_cmd'])
     args_left = assert_workdir_param(args_left, '/C/tmp/test')
     args_left = std_assert_hostname_param(args_left)
-    args_left = assert_volume_params(args_left, [('/home/test_user/.p4tickets:ro', str(home_temp_dir / 'dog_p4tickets.txt'))])
+    args_left = assert_volume_params(args_left, [('/home/dog_test_user/.p4tickets:ro', str(home_temp_dir / 'dog_p4tickets.txt'))])
     args_left = std_assert_interactive(args_left)
-    args_left = assert_env_params(args_left, ['USER=test_user', 'P4USER=test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
+    args_left = assert_env_params(args_left, ['USER=dog_test_user', 'P4USER=dog_test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=dog_test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/dog_test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
     assert args_left == []

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -148,8 +148,8 @@ def std_assert_volume_params(args_left):
     else:
         mount_point = str(find_mount_point(Path.cwd()))
         return assert_volume_params(args_left, [(mount_point, mount_point),
-                                                (f'/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')),
-                                                (f'/home/dog_test_user/.p4tickets:ro', str(Path.home() / '.p4tickets'))])
+                                                ('/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')),
+                                                ('/home/dog_test_user/.p4tickets:ro', str(Path.home() / '.p4tickets'))])
 
 
 def std_assert_interactive(args_left):

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -34,6 +34,7 @@ def mock_env_user(monkeypatch):
     if is_windows():
         monkeypatch.setenv('USERNAME', 'dog_test_user')
     else:
+        monkeypatch.setenv('ACTUAL_USER', os.getenv('USER'))
         monkeypatch.setenv('USER', 'dog_test_user')
     monkeypatch.setenv('P4USER', 'dog_test_user')
     monkeypatch.setenv('P4PORT', 'my_perforce_server:5000')
@@ -146,7 +147,7 @@ def std_assert_volume_params(args_left):
         return assert_volume_params(args_left, [('/C', 'C:\\'), ('/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')), ('/home/dog_test_user/.p4tickets:ro', str(Path.home() / 'dog_p4tickets.txt'))])
     else:
         mount_point = str(find_mount_point(Path.cwd()))
-        user = os.getenv('USER')
+        user = os.getenv('ACTUAL_USER')
         return assert_volume_params(args_left, [(mount_point, mount_point),
                                                 (f'/home/{user}/.ssh:ro', str(Path.home() / '.ssh')),
                                                 (f'/home/{user}/.p4tickets:ro', str(Path.home() / '.p4tickets'))])

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -10,7 +10,7 @@ import pytest
 
 import dog
 from conftest import append_to_dog_config, is_windows
-from dog import DogConfig, win32_to_dog_unix
+from dog import DogConfig, win32_to_dog_unix, find_mount_point
 
 
 class MockSubprocess:
@@ -146,7 +146,8 @@ def std_assert_volume_params(args_left):
     if is_windows():
         return assert_volume_params(args_left, [('/C', 'C:\\'), ('/home/dog_test_user/.ssh:ro', str(Path.home() / '.ssh')), ('/home/dog_test_user/.p4tickets:ro', str(Path.home() / 'dog_p4tickets.txt'))])
     else:
-        return assert_volume_params(args_left, [('/tmp', '/tmp'), ('/home/test_home/.ssh:ro', '/home/test_home/.ssh'), ('/home/test_home/.p4tickets:ro', '/home/test_home/.p4tickets')])
+        mount_point = str(find_mount_point(Path.cwd()))
+        return assert_volume_params(args_left, [(mount_point, mount_point), ('/home/test_home/.ssh:ro', '/home/test_home/.ssh'), ('/home/test_home/.p4tickets:ro', '/home/test_home/.p4tickets')])
 
 
 def std_assert_interactive(args_left):

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -30,7 +30,7 @@ def mock_subprocess(monkeypatch) -> MockSubprocess:
 
 
 @pytest.fixture(autouse=True)
-def mock_env_user(monkeypatch):
+def mock_env_user(monkeypatch, home_temp_dir):
     if is_windows():
         monkeypatch.setenv('USERNAME', 'dog_test_user')
     else:

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -258,4 +258,3 @@ def test_perforce_win32(call_main, tmp_path, mock_subprocess, monkeypatch, home_
     args_left = std_assert_interactive(args_left)
     args_left = assert_env_params(args_left, ['USER=test_user', 'P4USER=test_user', 'P4PORT=perforce.emea.demant.com:5000', 'DOG_UID=1000', 'DOG_GID=1000', 'DOG_USER=test_user', 'DOG_GROUP=nodoggroup', 'DOG_HOME=/home/test_user', 'DOG_AS_ROOT=False', 'DOG_PRESERVE_ENV=P4USER,P4PORT'])
     assert args_left == []
-

--- a/tests/test_docker_cmdline.py
+++ b/tests/test_docker_cmdline.py
@@ -228,7 +228,8 @@ def test_sudo_outside(call_main, tmp_path, mock_subprocess, test_sudo: List[Tupl
 if is_windows():
     DEFAULT_MOUNT_POINT = ('/C', 'C:\\')
 else:
-    DEFAULT_MOUNT_POINT = ('/tmp', '/tmp')
+    mount_point = str(find_mount_point(Path.cwd()))
+    DEFAULT_MOUNT_POINT = (mount_point, mount_point)
 
 
 @pytest.mark.parametrize('auto_mount', [('auto-mount=True', [DEFAULT_MOUNT_POINT]), ('auto-mount=False', []), ('', [DEFAULT_MOUNT_POINT])])

--- a/tests/test_perforce_config.py
+++ b/tests/test_perforce_config.py
@@ -14,7 +14,7 @@ def test_perforce_enabled(call_main, capstrip, tmp_path, home_dir_with_perforce_
     append_to_dog_config(tmp_path, '[dog]\nimage=rtol/centos-for-dog\n')
     call_main('cat', '~/.p4tickets')
     stdout, stderr = capstrip.get()
-    assert 'This is a mock p4 tickets file' in stdout
+    assert 'This is a mock p4 tickets file' in stdout, f'stdout:\n{stdout}\n\nstderr:\n{stderr}'
 
 
 def test_perforce_enabled_but_no_file(call_main, tmp_path, home_temp_dir):
@@ -27,4 +27,4 @@ def test_perforce_disabled(call_main, capstrip, tmp_path, home_dir_with_perforce
     append_to_dog_config(tmp_path, '\nperforce=False')
     call_main('cat', '~/.p4tickets')
     stdout, stderr = capstrip.get()
-    assert '.p4tickets: No such file or directory' in stderr
+    assert '.p4tickets: No such file or directory' in stderr, f'stdout:\n{stdout}\n\nstderr:\n{stderr}'

--- a/tests/test_perforce_config.py
+++ b/tests/test_perforce_config.py
@@ -12,7 +12,7 @@ def home_dir_with_perforce_file(home_temp_dir):
 
 def test_perforce_enabled(call_main, capstrip, tmp_path, home_dir_with_perforce_file):
     append_to_dog_config(tmp_path, '[dog]\nimage=rtol/centos-for-dog\n')
-    call_main('id')
+    call_main('--verbose', 'id')
     call_main('env')
     call_main('echo', '~/.p4tickets')
     call_main('ls', '-l', '~/.p4tickets')

--- a/tests/test_perforce_config.py
+++ b/tests/test_perforce_config.py
@@ -12,6 +12,12 @@ def home_dir_with_perforce_file(home_temp_dir):
 
 def test_perforce_enabled(call_main, capstrip, tmp_path, home_dir_with_perforce_file):
     append_to_dog_config(tmp_path, '[dog]\nimage=rtol/centos-for-dog\n')
+    call_main('echo', '~/.p4tickets')
+    call_main('ls', '-l', '~/.p4tickets')
+    stdout, stderr = capstrip.get()
+    print(stdout)
+    print(stderr)
+    stdout, stderr = capstrip.get()
     call_main('cat', '~/.p4tickets')
     stdout, stderr = capstrip.get()
     assert 'This is a mock p4 tickets file' in stdout, f'stdout:\n{stdout}\n\nstderr:\n{stderr}'

--- a/tests/test_perforce_config.py
+++ b/tests/test_perforce_config.py
@@ -1,12 +1,26 @@
+import os
+
 import pytest
 
 from conftest import append_to_dog_config
 
 
 @pytest.fixture
-def home_dir_with_perforce_file(home_temp_dir):
+def home_dir_with_perforce_file(home_temp_dir, monkeypatch, tmp_path):
     (home_temp_dir / '.p4tickets').write_text('This is a mock p4 tickets file')
     (home_temp_dir / 'p4tickets.txt').write_text('This is a mock p4 tickets file')
+
+    # Make the tmp_path (cwd) look like a mount point
+    real_os_path_is_mount = os.path.ismount
+
+    def my_is_mount(s):
+        if s == str(tmp_path):
+            return True
+        else:
+            return real_os_path_is_mount(s)
+
+    monkeypatch.setattr(os.path, 'ismount', my_is_mount)
+
     return home_temp_dir
 
 

--- a/tests/test_perforce_config.py
+++ b/tests/test_perforce_config.py
@@ -12,10 +12,6 @@ def home_dir_with_perforce_file(home_temp_dir):
 
 def test_perforce_enabled(call_main, capstrip, tmp_path, home_dir_with_perforce_file):
     append_to_dog_config(tmp_path, '[dog]\nimage=rtol/centos-for-dog\n')
-    call_main('--verbose', 'id')
-    call_main('env')
-    call_main('echo', '~/.p4tickets')
-    call_main('ls', '-l', '~/.p4tickets')
     call_main('cat', '~/.p4tickets')
     stdout, stderr = capstrip.get()
     assert 'This is a mock p4 tickets file' in stdout, f'stdout:\n{stdout}\n\nstderr:\n{stderr}'

--- a/tests/test_perforce_config.py
+++ b/tests/test_perforce_config.py
@@ -12,12 +12,10 @@ def home_dir_with_perforce_file(home_temp_dir):
 
 def test_perforce_enabled(call_main, capstrip, tmp_path, home_dir_with_perforce_file):
     append_to_dog_config(tmp_path, '[dog]\nimage=rtol/centos-for-dog\n')
+    call_main('id')
+    call_main('env')
     call_main('echo', '~/.p4tickets')
     call_main('ls', '-l', '~/.p4tickets')
-    stdout, stderr = capstrip.get()
-    print(stdout)
-    print(stderr)
-    stdout, stderr = capstrip.get()
     call_main('cat', '~/.p4tickets')
     stdout, stderr = capstrip.get()
     assert 'This is a mock p4 tickets file' in stdout, f'stdout:\n{stdout}\n\nstderr:\n{stderr}'


### PR DESCRIPTION
Add unit test of the command line used when running docker from dog - including a mocked Windows version.
Fixed a couple of minor issues in dog (e.g. constant usage).
Init. of Windows version of p4tickets moved, so perforce config option is taken into account.