### PR TITLE
Disable the k8s-for-dog workflow for the time being

### DIFF
--- a/.github/workflows/k8s-for-dog.yml
+++ b/.github/workflows/k8s-for-dog.yml
@@ -1,5 +1,6 @@
 name: k8s-for-dog
-on: [push]
+#on: [push]
+on: [workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It does not compile at the moment and gets in the way of other pull-requests.

Disabled by simple setting the workflow to on: workflow_dispatch